### PR TITLE
feat: add STL and OBJ export formats

### DIFF
--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,0 +1,5 @@
+mod obj;
+mod stl;
+
+pub use obj::triangles_to_obj;
+pub use stl::triangles_to_stl;

--- a/src/export/obj.rs
+++ b/src/export/obj.rs
@@ -1,0 +1,84 @@
+use crate::Triangle;
+
+/// Exports a slice of triangles to Wavefront OBJ format.
+/// Since the triangles are 2D, z coordinates are set to 0.
+/// Vertices are deduplicated by index and faces reference vertex positions.
+pub fn triangles_to_obj(triangles: &[Triangle]) -> String {
+    let mut vertices: Vec<(i64, f64, f64)> = Vec::new();
+
+    for triangle in triangles {
+        for vertex in &triangle.vertices() {
+            if !vertices.iter().any(|(idx, _, _)| *idx == vertex.index) {
+                vertices.push((vertex.index, vertex.x, vertex.y));
+            }
+        }
+    }
+
+    vertices.sort_by_key(|(idx, _, _)| *idx);
+
+    let mut result = String::new();
+
+    for (_, x, y) in &vertices {
+        result.push_str(&format!("v {} {} 0\n", x, y));
+    }
+
+    for triangle in triangles {
+        let a_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.a.index).unwrap() + 1;
+        let b_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.b.index).unwrap() + 1;
+        let c_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.c.index).unwrap() + 1;
+        result.push_str(&format!("f {} {} {}\n", a_pos, b_pos, c_pos));
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Point2D;
+
+    #[test]
+    fn test_triangles_to_obj_empty() {
+        let result = triangles_to_obj(&[]);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_triangles_to_obj_single_triangle() {
+        let triangles = vec![Triangle {
+            a: Point2D { index: 0, x: 0.0, y: 0.0 },
+            b: Point2D { index: 1, x: 1.0, y: 0.0 },
+            c: Point2D { index: 2, x: 0.0, y: 1.0 },
+        }];
+
+        let result = triangles_to_obj(&triangles);
+        assert!(result.contains("v 0 0 0"));
+        assert!(result.contains("v 1 0 0"));
+        assert!(result.contains("v 0 1 0"));
+        assert!(result.contains("f 1 2 3"));
+    }
+
+    #[test]
+    fn test_triangles_to_obj_shared_vertices() {
+        let triangles = vec![
+            Triangle {
+                a: Point2D { index: 0, x: 0.0, y: 0.0 },
+                b: Point2D { index: 1, x: 1.0, y: 0.0 },
+                c: Point2D { index: 2, x: 0.0, y: 1.0 },
+            },
+            Triangle {
+                a: Point2D { index: 1, x: 1.0, y: 0.0 },
+                b: Point2D { index: 3, x: 1.0, y: 1.0 },
+                c: Point2D { index: 2, x: 0.0, y: 1.0 },
+            },
+        ];
+
+        let result = triangles_to_obj(&triangles);
+        // Should have 4 unique vertices, not 6
+        let vertex_count = result.matches("\nv ").count() + if result.starts_with("v ") { 1 } else { 0 };
+        assert_eq!(vertex_count, 4);
+        // Two face lines
+        let face_count = result.matches("f ").count();
+        assert_eq!(face_count, 2);
+    }
+}

--- a/src/export/stl.rs
+++ b/src/export/stl.rs
@@ -1,0 +1,70 @@
+use crate::Triangle;
+
+/// Exports a slice of triangles to ASCII STL format.
+/// Since the triangles are 2D, z coordinates are set to 0
+/// and face normals point in the +z direction (0, 0, 1).
+pub fn triangles_to_stl(triangles: &[Triangle], name: &str) -> String {
+    let mut result = format!("solid {}\n", name);
+
+    for triangle in triangles {
+        result.push_str("  facet normal 0 0 1\n");
+        result.push_str("    outer loop\n");
+        for vertex in &triangle.vertices() {
+            result.push_str(&format!("      vertex {} {} 0\n", vertex.x, vertex.y));
+        }
+        result.push_str("    endloop\n");
+        result.push_str("  endfacet\n");
+    }
+
+    result.push_str(&format!("endsolid {}\n", name));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Point2D;
+
+    #[test]
+    fn test_triangles_to_stl_empty() {
+        let result = triangles_to_stl(&[], "test");
+        assert_eq!(result, "solid test\nendsolid test\n");
+    }
+
+    #[test]
+    fn test_triangles_to_stl_single_triangle() {
+        let triangles = vec![Triangle {
+            a: Point2D { index: 0, x: 0.0, y: 0.0 },
+            b: Point2D { index: 1, x: 1.0, y: 0.0 },
+            c: Point2D { index: 2, x: 0.0, y: 1.0 },
+        }];
+
+        let result = triangles_to_stl(&triangles, "mesh");
+        assert!(result.starts_with("solid mesh\n"));
+        assert!(result.ends_with("endsolid mesh\n"));
+        assert!(result.contains("facet normal 0 0 1"));
+        assert!(result.contains("vertex 0 0 0"));
+        assert!(result.contains("vertex 1 0 0"));
+        assert!(result.contains("vertex 0 1 0"));
+    }
+
+    #[test]
+    fn test_triangles_to_stl_multiple_triangles() {
+        let triangles = vec![
+            Triangle {
+                a: Point2D { index: 0, x: 0.0, y: 0.0 },
+                b: Point2D { index: 1, x: 1.0, y: 0.0 },
+                c: Point2D { index: 2, x: 0.0, y: 1.0 },
+            },
+            Triangle {
+                a: Point2D { index: 1, x: 1.0, y: 0.0 },
+                b: Point2D { index: 3, x: 1.0, y: 1.0 },
+                c: Point2D { index: 2, x: 0.0, y: 1.0 },
+            },
+        ];
+
+        let result = triangles_to_stl(&triangles, "quad");
+        let facet_count = result.matches("facet normal").count();
+        assert_eq!(facet_count, 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use geometry::{create_super_triangle, edge_is_shared_by_triangles, retriangulate
 pub use model::{Edge, Point2D, Triangle};
 use triangle_utils::remove_triangles_with_vertices_from_super_triangle;
 
+pub mod export;
 mod geometry;
 mod model;
 mod triangle_utils;


### PR DESCRIPTION
## Summary
- Add `export` module with support for ASCII STL and Wavefront OBJ file formats
- `triangles_to_stl()` exports triangles in ASCII STL format with z=0 for 2D meshes
- `triangles_to_obj()` exports triangles in Wavefront OBJ format with vertex deduplication
- Includes comprehensive tests for both exporters

## Test plan
- [x] Unit tests for empty input
- [x] Unit tests for single triangle export (STL and OBJ)
- [x] Unit tests for multiple triangles with shared vertices (STL and OBJ)
- [x] All 7 tests passing with `cargo test`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)