### PR TITLE
feat: implement Octree-based mesh generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod model;
 mod tetrahedron_utils;
 mod triangle_utils;
 pub mod advancing_front;
+pub mod octree;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -1,0 +1,137 @@
+use crate::{Point3D, Tetrahedron};
+
+#[derive(Clone, Copy)]
+struct Bounds {
+    min_x: f64,
+    min_y: f64,
+    min_z: f64,
+    max_x: f64,
+    max_y: f64,
+    max_z: f64,
+}
+
+fn subdivide(
+    b: Bounds,
+    depth: usize,
+    max_depth: usize,
+    is_inside: &dyn Fn(&Point3D) -> bool,
+    next_index: &mut i64,
+    tetrahedra: &mut Vec<Tetrahedron>,
+) {
+    if depth >= max_depth {
+        let center = Point3D {
+            index: -1,
+            x: (b.min_x + b.max_x) / 2.0,
+            y: (b.min_y + b.max_y) / 2.0,
+            z: (b.min_z + b.max_z) / 2.0,
+        };
+        if !is_inside(&center) {
+            return;
+        }
+
+        let idx = *next_index;
+        *next_index += 8;
+        let p = [
+            Point3D { index: idx, x: b.min_x, y: b.min_y, z: b.min_z },
+            Point3D { index: idx + 1, x: b.max_x, y: b.min_y, z: b.min_z },
+            Point3D { index: idx + 2, x: b.max_x, y: b.max_y, z: b.min_z },
+            Point3D { index: idx + 3, x: b.min_x, y: b.max_y, z: b.min_z },
+            Point3D { index: idx + 4, x: b.min_x, y: b.min_y, z: b.max_z },
+            Point3D { index: idx + 5, x: b.max_x, y: b.min_y, z: b.max_z },
+            Point3D { index: idx + 6, x: b.max_x, y: b.max_y, z: b.max_z },
+            Point3D { index: idx + 7, x: b.min_x, y: b.max_y, z: b.max_z },
+        ];
+
+        // Standard 5-tetrahedra decomposition of a hexahedron
+        tetrahedra.push(Tetrahedron { a: p[0], b: p[1], c: p[3], d: p[4] });
+        tetrahedra.push(Tetrahedron { a: p[1], b: p[2], c: p[3], d: p[6] });
+        tetrahedra.push(Tetrahedron { a: p[1], b: p[4], c: p[5], d: p[6] });
+        tetrahedra.push(Tetrahedron { a: p[3], b: p[4], c: p[6], d: p[7] });
+        tetrahedra.push(Tetrahedron { a: p[1], b: p[3], c: p[4], d: p[6] });
+        return;
+    }
+
+    let mid_x = (b.min_x + b.max_x) / 2.0;
+    let mid_y = (b.min_y + b.max_y) / 2.0;
+    let mid_z = (b.min_z + b.max_z) / 2.0;
+
+    let octants = [
+        Bounds { min_x: b.min_x, min_y: b.min_y, min_z: b.min_z, max_x: mid_x, max_y: mid_y, max_z: mid_z },
+        Bounds { min_x: mid_x, min_y: b.min_y, min_z: b.min_z, max_x: b.max_x, max_y: mid_y, max_z: mid_z },
+        Bounds { min_x: b.min_x, min_y: mid_y, min_z: b.min_z, max_x: mid_x, max_y: b.max_y, max_z: mid_z },
+        Bounds { min_x: mid_x, min_y: mid_y, min_z: b.min_z, max_x: b.max_x, max_y: b.max_y, max_z: mid_z },
+        Bounds { min_x: b.min_x, min_y: b.min_y, min_z: mid_z, max_x: mid_x, max_y: mid_y, max_z: b.max_z },
+        Bounds { min_x: mid_x, min_y: b.min_y, min_z: mid_z, max_x: b.max_x, max_y: mid_y, max_z: b.max_z },
+        Bounds { min_x: b.min_x, min_y: mid_y, min_z: mid_z, max_x: mid_x, max_y: b.max_y, max_z: b.max_z },
+        Bounds { min_x: mid_x, min_y: mid_y, min_z: mid_z, max_x: b.max_x, max_y: b.max_y, max_z: b.max_z },
+    ];
+
+    for octant in &octants {
+        subdivide(*octant, depth + 1, max_depth, is_inside, next_index, tetrahedra);
+    }
+}
+
+/// Generates a tetrahedral mesh using octree-based spatial subdivision.
+///
+/// Recursively subdivides the bounding box into octants up to `max_depth` levels.
+/// At each leaf cell whose center satisfies `is_inside`, a hexahedral cell is
+/// decomposed into 5 tetrahedra.
+pub fn octree_mesh(
+    min: Point3D,
+    max: Point3D,
+    max_depth: usize,
+    is_inside: &dyn Fn(&Point3D) -> bool,
+) -> Vec<Tetrahedron> {
+    let mut tetrahedra = Vec::new();
+    let mut next_index: i64 = 0;
+    let bounds = Bounds {
+        min_x: min.x,
+        min_y: min.y,
+        min_z: min.z,
+        max_x: max.x,
+        max_y: max.y,
+        max_z: max.z,
+    };
+    subdivide(bounds, 0, max_depth, is_inside, &mut next_index, &mut tetrahedra);
+    tetrahedra
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_cell_always_inside() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 0, &|_| true);
+        assert_eq!(result.len(), 5);
+    }
+
+    #[test]
+    fn test_depth_1_all_inside() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 1, &|_| true);
+        assert_eq!(result.len(), 40);
+    }
+
+    #[test]
+    fn test_sphere_containment() {
+        let min = Point3D { index: 0, x: -1.0, y: -1.0, z: -1.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 2, &|p| {
+            p.x * p.x + p.y * p.y + p.z * p.z <= 1.0
+        });
+        assert!(!result.is_empty());
+        assert!(result.len() < 64 * 5);
+    }
+
+    #[test]
+    fn test_empty_domain() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 2, &|_| false);
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `octree` module (`src/octree.rs`) implementing octree-based mesh generation
- Recursively subdivides bounding box into 8 octants; leaf cells whose center passes containment check are decomposed into 5 tetrahedra
- Includes 4 tests: single cell, depth-1 all inside (40 tets), sphere containment, empty domain

## Test plan
- [x] `cargo test` - all 16 tests pass (12 existing + 4 new)
- [x] `cargo clippy -- -D warnings` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)