### PR TITLE
feat: implement Marching Cubes algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod model;
 mod tetrahedron_utils;
 mod triangle_utils;
 pub mod advancing_front;
+pub mod marching_cubes;
 pub mod octree;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;


### PR DESCRIPTION
## Summary
- Add `marching_cubes` module (`src/marching_cubes.rs`) implementing the Marching Cubes algorithm for isosurface extraction
- Uses standard 256-configuration lookup tables (edge table + triangle table) to extract triangulated isosurfaces from 3D scalar fields
- Supports linear interpolation on intersected edges
- Includes 4 tests: sphere isosurface, all-above-iso empty, distinct vertices check, plane isosurface

## Test plan
- [x] `cargo test` - all 16 tests pass (12 existing + 4 new)
- [x] `cargo clippy -- -D warnings` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)