### PR TITLE
feat: implement Delaunay Refinement (Ruppert's Algorithm)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod model;
 mod tetrahedron_utils;
 mod triangle_utils;
 pub mod advancing_front;
+pub mod delaunay_refinement;
 pub mod marching_cubes;
 pub mod octree;
 pub mod voxel_mesh;


### PR DESCRIPTION
## Summary
- Add `delaunay_refinement` module (`src/delaunay_refinement.rs`) implementing mesh quality improvement
- Iteratively inserts circumcenters of poorly-shaped tetrahedra (high radius-to-edge ratio) until all elements meet quality threshold
- Builds on existing `bowyer_watson_3d` function
- Includes 3 tests: regular tetrahedron stability, cube vertices mesh, refinement count verification

## Test plan
- [x] `cargo test` - all 15 tests pass (12 existing + 3 new)
- [x] `cargo clippy -- -D warnings` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)