### PR TITLE
test: expand test coverage with edge cases and volume checks

### DIFF
--- a/src/advancing_front.rs
+++ b/src/advancing_front.rs
@@ -198,6 +198,37 @@ mod tests {
     }
 
     #[test]
+    fn test_all_tetrahedra_have_nonzero_volume() {
+        let p0 = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let p1 = Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 };
+        let p2 = Point3D { index: 2, x: 0.5, y: 1.0, z: 0.0 };
+        let p3 = Point3D { index: 3, x: 0.5, y: 0.3, z: 1.0 };
+
+        let faces = vec![
+            Face { a: p0, b: p2, c: p1 },
+            Face { a: p0, b: p1, c: p3 },
+            Face { a: p1, b: p2, c: p3 },
+            Face { a: p0, b: p3, c: p2 },
+        ];
+        let points = vec![p0, p1, p2, p3];
+        let result = advancing_front(faces, points);
+        for tet in &result {
+            assert!(tet.signed_volume().abs() > 1e-15, "Degenerate tetrahedron found");
+        }
+    }
+
+    #[test]
+    fn test_faces_no_points() {
+        // Faces provided but no points — should still generate via normal projection
+        let p0 = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let p1 = Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 };
+        let p2 = Point3D { index: 2, x: 0.5, y: 1.0, z: 0.0 };
+        let faces = vec![Face { a: p0, b: p1, c: p2 }];
+        let result = advancing_front(faces, Vec::new());
+        assert!(!result.is_empty());
+    }
+
+    #[test]
     fn test_cube_surface() {
         // 8 vertices of a unit cube
         let p = [

--- a/src/delaunay_refinement.rs
+++ b/src/delaunay_refinement.rs
@@ -92,6 +92,38 @@ mod tests {
     }
 
     #[test]
+    fn test_tight_threshold_adds_points() {
+        let points = vec![
+            Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 },
+            Point3D { index: 3, x: 1.0, y: 1.0, z: 0.0 },
+            Point3D { index: 4, x: 0.0, y: 0.0, z: 1.0 },
+            Point3D { index: 5, x: 1.0, y: 0.0, z: 1.0 },
+            Point3D { index: 6, x: 0.0, y: 1.0, z: 1.0 },
+            Point3D { index: 7, x: 1.0, y: 1.0, z: 1.0 },
+        ];
+        let initial = bowyer_watson_3d(points.clone());
+        // Moderate threshold triggers some refinement
+        let refined = delaunay_refinement(points, 1.5);
+        assert!(refined.len() >= initial.len());
+    }
+
+    #[test]
+    fn test_all_refined_tetrahedra_have_nonzero_volume() {
+        let points = vec![
+            Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            Point3D { index: 2, x: 0.5, y: 1.0, z: 0.0 },
+            Point3D { index: 3, x: 0.5, y: 0.5, z: 1.0 },
+        ];
+        let result = delaunay_refinement(points, 2.0);
+        for tet in &result {
+            assert!(tet.signed_volume().abs() > 1e-15, "Degenerate tetrahedron found");
+        }
+    }
+
+    #[test]
     fn test_refinement_produces_at_least_as_many_tets() {
         let points = vec![
             Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },

--- a/src/marching_cubes.rs
+++ b/src/marching_cubes.rs
@@ -508,6 +508,40 @@ mod tests {
     }
 
     #[test]
+    fn test_all_below_iso_returns_empty() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let field = |_x: f64, _y: f64, _z: f64| -10.0;
+        let faces = marching_cubes(5, 5, 5, min, max, &field, 0.0);
+        assert!(faces.is_empty(), "All below iso should produce no faces");
+    }
+
+    #[test]
+    fn test_higher_resolution_produces_more_faces() {
+        let min = Point3D { index: 0, x: -2.0, y: -2.0, z: -2.0 };
+        let max = Point3D { index: 0, x: 2.0, y: 2.0, z: 2.0 };
+        let field = |x: f64, y: f64, z: f64| x * x + y * y + z * z - 1.0;
+        let low = marching_cubes(5, 5, 5, min, max, &field, 0.0);
+        let high = marching_cubes(10, 10, 10, min, max, &field, 0.0);
+        assert!(high.len() > low.len(), "Higher resolution should produce more faces");
+    }
+
+    #[test]
+    fn test_torus_isosurface() {
+        let min = Point3D { index: 0, x: -3.0, y: -3.0, z: -1.5 };
+        let max = Point3D { index: 0, x: 3.0, y: 3.0, z: 1.5 };
+        // Torus: (sqrt(x²+y²) - R)² + z² - r² = 0, R=2, r=0.5
+        let field = |x: f64, y: f64, z: f64| {
+            let r_big = 2.0;
+            let r_small = 0.5;
+            let xy = (x * x + y * y).sqrt();
+            (xy - r_big) * (xy - r_big) + z * z - r_small * r_small
+        };
+        let faces = marching_cubes(15, 15, 8, min, max, &field, 0.0);
+        assert!(!faces.is_empty(), "Torus should produce faces");
+    }
+
+    #[test]
     fn test_plane_isosurface() {
         let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
         let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };

--- a/src/model/tetrahedron.rs
+++ b/src/model/tetrahedron.rs
@@ -85,6 +85,19 @@ impl Tetrahedron {
         [self.a, self.b, self.c, self.d]
     }
 
+    pub fn signed_volume(&self) -> f64 {
+        let ux = self.b.x - self.a.x;
+        let uy = self.b.y - self.a.y;
+        let uz = self.b.z - self.a.z;
+        let vx = self.c.x - self.a.x;
+        let vy = self.c.y - self.a.y;
+        let vz = self.c.z - self.a.z;
+        let wx = self.d.x - self.a.x;
+        let wy = self.d.y - self.a.y;
+        let wz = self.d.z - self.a.z;
+        (ux * (vy * wz - vz * wy) - uy * (vx * wz - vz * wx) + uz * (vx * wy - vy * wx)) / 6.0
+    }
+
     pub fn contains_face(&self, face: &Face) -> bool {
         let verts = self.vertices();
         verts.contains(&face.a) && verts.contains(&face.b) && verts.contains(&face.c)

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -128,6 +128,35 @@ mod tests {
     }
 
     #[test]
+    fn test_all_tetrahedra_have_nonzero_volume() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 2, &|_| true);
+        for tet in &result {
+            assert!(tet.signed_volume().abs() > 1e-15, "Degenerate tetrahedron found");
+        }
+    }
+
+    #[test]
+    fn test_depth_2_cell_count() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_mesh(min, max, 2, &|_| true);
+        // depth=2 → 64 leaf cells × 5 tets = 320
+        assert_eq!(result.len(), 320);
+    }
+
+    #[test]
+    fn test_partial_containment() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 2.0, y: 2.0, z: 2.0 };
+        // Only accept cells whose center x < 1.0 (half the domain)
+        let result = octree_mesh(min, max, 1, &|p| p.x < 1.0);
+        // 8 octants at depth 1, 4 have center.x < 1.0
+        assert_eq!(result.len(), 4 * 5);
+    }
+
+    #[test]
     fn test_empty_domain() {
         let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
         let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };

--- a/src/voxel_mesh.rs
+++ b/src/voxel_mesh.rs
@@ -140,6 +140,25 @@ mod tests {
     }
 
     #[test]
+    fn test_all_tetrahedra_have_nonzero_volume() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = voxel_mesh(min, max, 3, 3, 3, &|_| true);
+        for tet in &result {
+            assert!(tet.signed_volume().abs() > 1e-15, "Degenerate tetrahedron found");
+        }
+    }
+
+    #[test]
+    fn test_asymmetric_resolution() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = voxel_mesh(min, max, 1, 2, 3, &|_| true);
+        // 1×2×3 = 6 cells × 5 tets = 30
+        assert_eq!(result.len(), 30);
+    }
+
+    #[test]
     fn test_shared_vertex_indices() {
         let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
         let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };


### PR DESCRIPTION
## Summary
- Add `signed_volume()` method to `Tetrahedron` for non-degeneracy validation
- Add 12 new tests across all 5 algorithm modules (31 → 43 total tests)
- Volume non-degeneracy checks for advancing_front, octree, voxel_mesh, delaunay_refinement
- Edge cases: faces with no points, partial containment, asymmetric resolution, torus isosurface

Closes #20

## Test plan
- [x] `cargo test` — 43 tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)