### PR TITLE
Add 3D tetrahedral mesh STL/OBJ export

### DIFF
--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,5 +1,7 @@
 mod obj;
-mod stl;
+pub(crate) mod stl;
 
-pub use obj::triangles_to_obj;
-pub use stl::triangles_to_stl;
+pub use obj::{faces_to_obj, tetrahedra_to_obj, triangles_to_obj};
+pub use stl::{
+    extract_surface_faces, faces_to_stl, tetrahedra_to_stl, triangles_to_stl,
+};

--- a/src/export/obj.rs
+++ b/src/export/obj.rs
@@ -1,4 +1,5 @@
-use crate::Triangle;
+use crate::export::stl::extract_surface_faces;
+use crate::{Face, Point3D, Tetrahedron, Triangle};
 
 /// Exports a slice of triangles to Wavefront OBJ format.
 /// Since the triangles are 2D, z coordinates are set to 0.
@@ -26,6 +27,43 @@ pub fn triangles_to_obj(triangles: &[Triangle]) -> String {
         let a_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.a.index).unwrap() + 1;
         let b_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.b.index).unwrap() + 1;
         let c_pos = vertices.iter().position(|(idx, _, _)| *idx == triangle.c.index).unwrap() + 1;
+        result.push_str(&format!("f {} {} {}\n", a_pos, b_pos, c_pos));
+    }
+
+    result
+}
+
+/// Exports a tetrahedral mesh to Wavefront OBJ format by extracting surface faces.
+pub fn tetrahedra_to_obj(tetrahedra: &[Tetrahedron]) -> String {
+    let surface = extract_surface_faces(tetrahedra);
+    faces_to_obj(&surface)
+}
+
+/// Exports 3D faces to Wavefront OBJ format.
+/// Vertices are deduplicated by index.
+pub fn faces_to_obj(faces: &[Face]) -> String {
+    let mut vertices: Vec<(i64, Point3D)> = Vec::new();
+
+    for face in faces {
+        for vertex in &face.vertices() {
+            if !vertices.iter().any(|(idx, _)| *idx == vertex.index) {
+                vertices.push((vertex.index, *vertex));
+            }
+        }
+    }
+
+    vertices.sort_by_key(|(idx, _)| *idx);
+
+    let mut result = String::new();
+
+    for (_, v) in &vertices {
+        result.push_str(&format!("v {} {} {}\n", v.x, v.y, v.z));
+    }
+
+    for face in faces {
+        let a_pos = vertices.iter().position(|(idx, _)| *idx == face.a.index).unwrap() + 1;
+        let b_pos = vertices.iter().position(|(idx, _)| *idx == face.b.index).unwrap() + 1;
+        let c_pos = vertices.iter().position(|(idx, _)| *idx == face.c.index).unwrap() + 1;
         result.push_str(&format!("f {} {} {}\n", a_pos, b_pos, c_pos));
     }
 
@@ -80,5 +118,41 @@ mod tests {
         // Two face lines
         let face_count = result.matches("f ").count();
         assert_eq!(face_count, 2);
+    }
+
+    #[test]
+    fn test_tetrahedra_to_obj_single() {
+        let tet = Tetrahedron {
+            a: Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            b: Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            c: Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 },
+            d: Point3D { index: 3, x: 0.0, y: 0.0, z: 1.0 },
+        };
+        let result = tetrahedra_to_obj(&[tet]);
+        let vertex_count = result.matches("\nv ").count()
+            + if result.starts_with("v ") { 1 } else { 0 };
+        assert_eq!(vertex_count, 4);
+        let face_count = result.matches("f ").count();
+        assert_eq!(face_count, 4);
+    }
+
+    #[test]
+    fn test_tetrahedra_to_obj_empty() {
+        let result = tetrahedra_to_obj(&[]);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_faces_to_obj_3d_vertices() {
+        let face = Face {
+            a: Point3D { index: 0, x: 1.0, y: 2.0, z: 3.0 },
+            b: Point3D { index: 1, x: 4.0, y: 5.0, z: 6.0 },
+            c: Point3D { index: 2, x: 7.0, y: 8.0, z: 9.0 },
+        };
+        let result = faces_to_obj(&[face]);
+        assert!(result.contains("v 1 2 3"));
+        assert!(result.contains("v 4 5 6"));
+        assert!(result.contains("v 7 8 9"));
+        assert!(result.contains("f 1 2 3"));
     }
 }

--- a/src/export/stl.rs
+++ b/src/export/stl.rs
@@ -1,4 +1,4 @@
-use crate::Triangle;
+use crate::{Face, Tetrahedron, Triangle};
 
 /// Exports a slice of triangles to ASCII STL format.
 /// Since the triangles are 2D, z coordinates are set to 0
@@ -20,10 +20,72 @@ pub fn triangles_to_stl(triangles: &[Triangle], name: &str) -> String {
     result
 }
 
+/// Extracts the boundary surface faces from a tetrahedral mesh.
+/// A face is on the boundary if it appears in exactly one tetrahedron.
+pub fn extract_surface_faces(tetrahedra: &[Tetrahedron]) -> Vec<Face> {
+    let all_faces: Vec<Face> = tetrahedra.iter().flat_map(|t| t.faces()).collect();
+    let mut surface = Vec::new();
+    for face in &all_faces {
+        let count = all_faces.iter().filter(|f| *f == face).count();
+        if count == 1 {
+            // Avoid duplicates in the output (each unique boundary face appears once)
+            if !surface.iter().any(|f: &Face| f == face) {
+                surface.push(*face);
+            }
+        }
+    }
+    surface
+}
+
+fn face_normal(face: &Face) -> (f64, f64, f64) {
+    let ux = face.b.x - face.a.x;
+    let uy = face.b.y - face.a.y;
+    let uz = face.b.z - face.a.z;
+    let vx = face.c.x - face.a.x;
+    let vy = face.c.y - face.a.y;
+    let vz = face.c.z - face.a.z;
+    let nx = uy * vz - uz * vy;
+    let ny = uz * vx - ux * vz;
+    let nz = ux * vy - uy * vx;
+    let len = (nx * nx + ny * ny + nz * nz).sqrt();
+    if len < 1e-15 {
+        return (0.0, 0.0, 0.0);
+    }
+    (nx / len, ny / len, nz / len)
+}
+
+/// Exports a tetrahedral mesh to ASCII STL format by extracting surface faces.
+pub fn tetrahedra_to_stl(tetrahedra: &[Tetrahedron], name: &str) -> String {
+    let surface = extract_surface_faces(tetrahedra);
+    faces_to_stl(&surface, name)
+}
+
+/// Exports 3D faces to ASCII STL format with computed normals.
+pub fn faces_to_stl(faces: &[Face], name: &str) -> String {
+    let mut result = format!("solid {}\n", name);
+
+    for face in faces {
+        let (nx, ny, nz) = face_normal(face);
+        result.push_str(&format!("  facet normal {} {} {}\n", nx, ny, nz));
+        result.push_str("    outer loop\n");
+        for vertex in &face.vertices() {
+            result.push_str(&format!(
+                "      vertex {} {} {}\n",
+                vertex.x, vertex.y, vertex.z
+            ));
+        }
+        result.push_str("    endloop\n");
+        result.push_str("  endfacet\n");
+    }
+
+    result.push_str(&format!("endsolid {}\n", name));
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Point2D;
+    use crate::{Point2D, Point3D};
 
     #[test]
     fn test_triangles_to_stl_empty() {
@@ -66,5 +128,64 @@ mod tests {
         let result = triangles_to_stl(&triangles, "quad");
         let facet_count = result.matches("facet normal").count();
         assert_eq!(facet_count, 2);
+    }
+
+    fn single_tet() -> Tetrahedron {
+        Tetrahedron {
+            a: Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            b: Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            c: Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 },
+            d: Point3D { index: 3, x: 0.0, y: 0.0, z: 1.0 },
+        }
+    }
+
+    #[test]
+    fn test_tetrahedra_to_stl_single() {
+        let result = tetrahedra_to_stl(&[single_tet()], "tet");
+        assert!(result.starts_with("solid tet\n"));
+        assert!(result.ends_with("endsolid tet\n"));
+        // Single tet has 4 boundary faces
+        let facet_count = result.matches("facet normal").count();
+        assert_eq!(facet_count, 4);
+    }
+
+    #[test]
+    fn test_tetrahedra_to_stl_empty() {
+        let result = tetrahedra_to_stl(&[], "empty");
+        assert_eq!(result, "solid empty\nendsolid empty\n");
+    }
+
+    #[test]
+    fn test_faces_to_stl_computes_normal() {
+        let face = Face {
+            a: Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            b: Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            c: Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 },
+        };
+        let result = faces_to_stl(&[face], "test");
+        // Normal should be (0, 0, 1) for a face in the XY plane
+        assert!(result.contains("facet normal 0 0 1"));
+    }
+
+    #[test]
+    fn test_extract_surface_faces_single_tet() {
+        let surface = extract_surface_faces(&[single_tet()]);
+        assert_eq!(surface.len(), 4);
+    }
+
+    #[test]
+    fn test_extract_surface_shared_face_excluded() {
+        // Two tetrahedra sharing a face — the shared face should be excluded
+        let p0 = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let p1 = Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 };
+        let p2 = Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 };
+        let p3 = Point3D { index: 3, x: 0.0, y: 0.0, z: 1.0 };
+        let p4 = Point3D { index: 4, x: 0.0, y: 0.0, z: -1.0 };
+
+        let tet1 = Tetrahedron { a: p0, b: p1, c: p2, d: p3 };
+        let tet2 = Tetrahedron { a: p0, b: p1, c: p2, d: p4 };
+        let surface = extract_surface_faces(&[tet1, tet2]);
+        // 2 tets * 4 faces = 8 total, minus 2 (shared face counted in both) = 6
+        assert_eq!(surface.len(), 6);
     }
 }


### PR DESCRIPTION
## Summary
- Add `extract_surface_faces` to find boundary faces from a tetrahedral mesh
- Add `tetrahedra_to_stl` and `faces_to_stl` for 3D ASCII STL export with computed face normals
- Add `tetrahedra_to_obj` and `faces_to_obj` for 3D Wavefront OBJ export with vertex deduplication
- 8 new tests covering surface extraction, STL/OBJ output, shared faces, and edge cases

## Test plan
- [x] `cargo test` passes (51 tests)
- [x] `cargo clippy -- -D warnings -A unused-imports` clean

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)