### PR TITLE
Add algorithm composition pipeline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod advancing_front;
 pub mod delaunay_refinement;
 pub mod marching_cubes;
 pub mod octree;
+pub mod pipeline;
 pub mod voxel_mesh;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,181 @@
+use crate::advancing_front::advancing_front;
+use crate::delaunay_refinement::delaunay_refinement;
+use crate::marching_cubes::marching_cubes;
+use crate::octree::octree_mesh;
+use crate::voxel_mesh::voxel_mesh;
+use crate::{Face, Point3D, Tetrahedron};
+
+/// Extracts unique points from a tetrahedral mesh.
+fn extract_unique_points(tetrahedra: &[Tetrahedron]) -> Vec<Point3D> {
+    let mut points: Vec<Point3D> = Vec::new();
+    for tet in tetrahedra {
+        for v in tet.vertices() {
+            if !points.iter().any(|p| p.index == v.index) {
+                points.push(v);
+            }
+        }
+    }
+    points.sort_by_key(|p| p.index);
+    points
+}
+
+/// Runs Marching Cubes to extract a surface, then fills the interior with
+/// Advancing Front to produce a tetrahedral volume mesh.
+pub fn surface_to_volume(
+    nx: usize,
+    ny: usize,
+    nz: usize,
+    min: Point3D,
+    max: Point3D,
+    scalar_field: &dyn Fn(f64, f64, f64) -> f64,
+    iso_value: f64,
+) -> Vec<Tetrahedron> {
+    let faces = marching_cubes(nx, ny, nz, min, max, scalar_field, iso_value);
+    if faces.is_empty() {
+        return Vec::new();
+    }
+    let points = collect_face_points(&faces);
+    advancing_front(faces, points)
+}
+
+/// Generates an octree mesh and then refines it for quality.
+pub fn octree_refined(
+    min: Point3D,
+    max: Point3D,
+    max_depth: usize,
+    is_inside: &dyn Fn(&Point3D) -> bool,
+    max_radius_edge_ratio: f64,
+) -> Vec<Tetrahedron> {
+    let tets = octree_mesh(min, max, max_depth, is_inside);
+    if tets.is_empty() {
+        return Vec::new();
+    }
+    let points = extract_unique_points(&tets);
+    delaunay_refinement(points, max_radius_edge_ratio)
+}
+
+/// Generates a voxel mesh and then refines it for quality.
+pub fn voxel_refined(
+    min: Point3D,
+    max: Point3D,
+    nx: usize,
+    ny: usize,
+    nz: usize,
+    is_inside: &dyn Fn(&Point3D) -> bool,
+    max_radius_edge_ratio: f64,
+) -> Vec<Tetrahedron> {
+    let tets = voxel_mesh(min, max, nx, ny, nz, is_inside);
+    if tets.is_empty() {
+        return Vec::new();
+    }
+    let points = extract_unique_points(&tets);
+    delaunay_refinement(points, max_radius_edge_ratio)
+}
+
+/// Applies Delaunay refinement to an existing tetrahedral mesh by extracting
+/// its unique vertices and re-meshing with quality constraints.
+pub fn refine_tetrahedra(
+    tetrahedra: &[Tetrahedron],
+    max_radius_edge_ratio: f64,
+) -> Vec<Tetrahedron> {
+    if tetrahedra.is_empty() {
+        return Vec::new();
+    }
+    let points = extract_unique_points(tetrahedra);
+    delaunay_refinement(points, max_radius_edge_ratio)
+}
+
+fn collect_face_points(faces: &[Face]) -> Vec<Point3D> {
+    let mut points: Vec<Point3D> = Vec::new();
+    for face in faces {
+        for v in face.vertices() {
+            if !points.iter().any(|p| p.index == v.index) {
+                points.push(v);
+            }
+        }
+    }
+    points.sort_by_key(|p| p.index);
+    points
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sphere_field(x: f64, y: f64, z: f64) -> f64 {
+        x * x + y * y + z * z - 1.0
+    }
+
+    #[test]
+    fn test_surface_to_volume_sphere() {
+        let min = Point3D { index: 0, x: -2.0, y: -2.0, z: -2.0 };
+        let max = Point3D { index: 0, x: 2.0, y: 2.0, z: 2.0 };
+        let result = surface_to_volume(8, 8, 8, min, max, &sphere_field, 0.0);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_surface_to_volume_empty_field() {
+        let min = Point3D { index: 0, x: -1.0, y: -1.0, z: -1.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        // Field always positive → no isosurface
+        let result = surface_to_volume(4, 4, 4, min, max, &|_, _, _| 10.0, 0.0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_octree_refined() {
+        let min = Point3D { index: 0, x: -1.0, y: -1.0, z: -1.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        // Use depth=1 and loose ratio to keep test fast
+        let result = octree_refined(min, max, 1, &|_| true, 2.0);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_voxel_refined() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        // Use 2x2x2 and loose ratio to keep test fast
+        let result = voxel_refined(min, max, 2, 2, 2, &|_| true, 2.0);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_refine_tetrahedra_empty() {
+        let result = refine_tetrahedra(&[], 2.0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_refine_tetrahedra_single() {
+        let tet = Tetrahedron {
+            a: Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            b: Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            c: Point3D { index: 2, x: 0.5, y: 1.0, z: 0.0 },
+            d: Point3D { index: 3, x: 0.5, y: 0.5, z: 1.0 },
+        };
+        let result = refine_tetrahedra(&[tet], 2.0);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_octree_refined_empty_domain() {
+        let min = Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 };
+        let max = Point3D { index: 0, x: 1.0, y: 1.0, z: 1.0 };
+        let result = octree_refined(min, max, 2, &|_| false, 2.0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_extract_unique_points() {
+        let tet = Tetrahedron {
+            a: Point3D { index: 0, x: 0.0, y: 0.0, z: 0.0 },
+            b: Point3D { index: 1, x: 1.0, y: 0.0, z: 0.0 },
+            c: Point3D { index: 2, x: 0.0, y: 1.0, z: 0.0 },
+            d: Point3D { index: 3, x: 0.0, y: 0.0, z: 1.0 },
+        };
+        let points = extract_unique_points(&[tet]);
+        assert_eq!(points.len(), 4);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `src/pipeline.rs` module with composable meshing workflow functions:
  - `surface_to_volume`: Marching Cubes surface extraction → Advancing Front interior fill
  - `octree_refined`: Octree mesh → Delaunay Refinement quality improvement
  - `voxel_refined`: Voxel mesh → Delaunay Refinement quality improvement
  - `refine_tetrahedra`: apply Delaunay refinement to any existing tetrahedral mesh
- 8 new tests covering all pipeline compositions and edge cases

## Test plan
- [x] `cargo test` passes (59 tests)
- [x] `cargo clippy -- -D warnings -A unused-imports` clean

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)