### PR TITLE
Fix unused Circle import warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 use error::MeshingError;
 use geometry::{create_super_triangle, edge_is_shared_by_triangles, retriangulate};
 use geometry_3d::{create_super_tetrahedron, face_is_shared_by_tetrahedra, retetrahedralize};
-pub use model::{Edge, Face, Point2D, Point3D, Sphere, Tetrahedron, Triangle};
+pub use model::{Circle, Edge, Face, Point2D, Point3D, Sphere, Tetrahedron, Triangle};
 use tetrahedron_utils::remove_tetrahedra_with_vertices_from_super_tetrahedron;
 use triangle_utils::remove_triangles_with_vertices_from_super_triangle;
 


### PR DESCRIPTION
## Summary
- Re-export `Circle` from the crate's public API in `lib.rs`
- This resolves the long-standing unused import warning in `model.rs`
- `cargo clippy -- -D warnings` now passes **without** `-A unused-imports`

## Test plan
- [x] `cargo test` passes (59 tests)
- [x] `cargo clippy -- -D warnings` clean (no more `-A unused-imports` needed)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)