### PR TITLE
Expand export format tests with programmatic mesh generation

### DIFF
--- a/src/export/obj.rs
+++ b/src/export/obj.rs
@@ -251,4 +251,142 @@ mod tests {
         assert!(result.contains("v 7 8 9"));
         assert!(result.contains("f 1 2 3"));
     }
+
+    #[test]
+    fn test_obj_from_marching_cubes_sphere() {
+        use crate::marching_cubes::marching_cubes;
+        let min = Point3D {
+            index: 0,
+            x: -2.0,
+            y: -2.0,
+            z: -2.0,
+        };
+        let max = Point3D {
+            index: 0,
+            x: 2.0,
+            y: 2.0,
+            z: 2.0,
+        };
+        let faces = marching_cubes(
+            6,
+            6,
+            6,
+            min,
+            max,
+            &|x, y, z| x * x + y * y + z * z - 1.0,
+            0.0,
+        );
+        assert!(!faces.is_empty());
+
+        let obj = faces_to_obj(&faces);
+        let vertex_lines: Vec<&str> = obj.lines().filter(|l| l.starts_with("v ")).collect();
+        let face_lines: Vec<&str> = obj.lines().filter(|l| l.starts_with("f ")).collect();
+        assert!(!vertex_lines.is_empty());
+        assert_eq!(face_lines.len(), faces.len());
+
+        // Every face index should be valid (1-based, within vertex count)
+        let num_verts = vertex_lines.len();
+        for line in &face_lines {
+            let indices: Vec<usize> = line[2..]
+                .split_whitespace()
+                .map(|s| s.parse::<usize>().unwrap())
+                .collect();
+            assert_eq!(indices.len(), 3);
+            for idx in indices {
+                assert!(idx >= 1 && idx <= num_verts);
+            }
+        }
+    }
+
+    #[test]
+    fn test_obj_face_indices_one_based() {
+        let face = Face {
+            a: Point3D {
+                index: 5,
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            b: Point3D {
+                index: 10,
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            c: Point3D {
+                index: 15,
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            },
+        };
+        let obj = faces_to_obj(&[face]);
+        // Indices should be 1, 2, 3 regardless of Point3D.index values
+        assert!(obj.contains("f 1 2 3"));
+    }
+
+    #[test]
+    fn test_obj_tetrahedra_surface_extraction() {
+        // A single tetrahedron should produce 4 faces and 4 vertices in OBJ
+        let tet = Tetrahedron {
+            a: Point3D {
+                index: 0,
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            b: Point3D {
+                index: 1,
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            c: Point3D {
+                index: 2,
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            },
+            d: Point3D {
+                index: 3,
+                x: 0.0,
+                y: 0.0,
+                z: 1.0,
+            },
+        };
+        let obj = tetrahedra_to_obj(&[tet]);
+        let v_count = obj.lines().filter(|l| l.starts_with("v ")).count();
+        let f_count = obj.lines().filter(|l| l.starts_with("f ")).count();
+        assert_eq!(v_count, 4);
+        assert_eq!(f_count, 4);
+    }
+
+    #[test]
+    fn test_obj_vertex_precision() {
+        let face = Face {
+            a: Point3D {
+                index: 0,
+                x: 0.123456789,
+                y: -0.987654321,
+                z: 42.0,
+            },
+            b: Point3D {
+                index: 1,
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            c: Point3D {
+                index: 2,
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            },
+        };
+        let obj = faces_to_obj(&[face]);
+        // Verify coordinates appear in the output
+        assert!(obj.contains("0.123456789"));
+        assert!(obj.contains("-0.987654321"));
+        assert!(obj.contains("42"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add 24 new tests across all 5 export format modules (STL, OBJ, VTK, glTF/GLB, Quantized GLB)
- Tests use marching cubes sphere and voxel mesh for realistic multi-face inputs
- Deep structural validation: GLB chunk parsing, VTK cell index ranges, STL facet structure, OBJ index validity
- Test count increased from 80 to 104

## Test coverage by format
| Format | New Tests | Key Validations |
|---|---|---|
| STL | 4 | Sphere mesh, normal directions, facet structure, coordinate preservation |
| OBJ | 4 | Sphere mesh, 1-based indices, surface extraction, vertex precision |
| VTK | 3 | Voxel mesh, cell index ranges, shared vertex dedup |
| glTF/GLB | 5 | Sphere mesh, chunk parsing, accessor counts, bounds, two-chunk structure |
| Quantized GLB | 5 | Sphere mesh, node matrix, i16 range, buffer size, comparison with regular GLB |

## Test plan
- [x] `cargo test` — 104 tests + 11 doc-tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)